### PR TITLE
Add exported types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "module": "dist/index.mjs",
   "exports": {
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "keywords": [
     "vite",


### PR DESCRIPTION
Current version not works without `"moduleResolution": "bundler"`:

```
  There are types at '/Users/azat/Developer/project/node_modules/vite-plugin-preload/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vite-plugin-preload' library may need to update its package.json or typings.

 import preload from 'vite-plugin-preload'
```