### PR TITLE
Add preload data to manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ export default defineConfig({
 });
 ```
 
+### Options
+
+```ts
+interface PreloadOptions {
+  includeJs: boolean;
+  includeCss: boolean;
+  format?: boolean | Omit<PrettierOptions, "parser">;
+  mode?: 'preload' | 'prefetch';
+  shouldPreload: (chunkInfo: OutputChunk | OutputAsset) => boolean;
+  generatePreloadManifestJsonPath?: string
+}
+```
+
 Html before:
 
 ```html
@@ -90,7 +103,7 @@ If you however decide to use the react way of performing code splitting by trigg
 
 In short. Performance and stability.
 
-### Performance. Developer performance that is.
+### Performance. Developer performance that is
 
 Code splitting is good for developer performance. As your code base grows, more files are sent from your
 src directory when starting the vite dev server. This can be slow. Really slow. Why pre-serve the entire code base when its not needed. Using code splitting with Reacy.lazy, vite is only serving the modules used for the currently loaded component tree and load more chunks is performed async. Hurray

--- a/examples/react-demo/vite.config.ts
+++ b/examples/react-demo/vite.config.ts
@@ -3,6 +3,14 @@ import react from "@vitejs/plugin-react";
 import preload from "vite-plugin-preload";
 
 export default defineConfig({
-  plugins: [react(), preload()],
+  plugins: [
+    react(),
+    preload({
+      generatePreloadManifestJsonPath: ".vite/manifest.json",
+    }),
+  ],
   base: "http://www.example.com",
+  build: {
+    manifest: true,
+  },
 });

--- a/specs/integration.spec.ts
+++ b/specs/integration.spec.ts
@@ -79,17 +79,12 @@ describe("vite-plugin-preload", () => {
 
   it("manifest json includes preload information", async () => {
     expect(fs.existsSync(manifestFile));
+    const jsChunks = getFiles(assetsDirectory, "js");
+    const jsRefs = jsChunks.map((c) => `http://www.example.com/assets/${c}`);
+    const cssChunks = getFiles(assetsDirectory, "css");
+    const cssRefs = cssChunks.map((c) => `http://www.example.com/assets/${c}`);
     const manifestJson = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
-    expect(manifestJson.preloadModules).toStrictEqual([
-      'http:/www.example.com/assets/index-anaWoCzC.js',
-      'http:/www.example.com/assets/index-B2KHv6gp.js',
-      'http:/www.example.com/assets/index-DR3rjWxH.js',
-      'http:/www.example.com/assets/index-q1TMq3ZU.js'
-    ])
-    expect(manifestJson.preloadStylesheets).toStrictEqual([
-      'http:/www.example.com/assets/index-8_aBiA4K.css',
-      'http:/www.example.com/assets/index-D8XkVD9g.css',
-      'http:/www.example.com/assets/index-DgcS6T3X.css'
-    ])
+    manifestJson.preloadModules.forEach((r) => expect(jsRefs).contains(r));
+    manifestJson.preloadStylesheets.forEach((r) => expect(cssRefs).contains(r));
   });
 });

--- a/specs/integration.spec.ts
+++ b/specs/integration.spec.ts
@@ -5,6 +5,7 @@ import { JSDOM } from "jsdom";
 const dist = "examples/react-demo/dist";
 const htmlFile = `${dist}/index.html`;
 const assetsDirectory = `${dist}/assets`;
+const manifestFile = `${dist}/.vite/manifest.json`;
 
 export const getDom = (): JSDOM => {
   const htmlContent = fs.readFileSync(htmlFile, {
@@ -74,5 +75,21 @@ describe("vite-plugin-preload", () => {
     const cssRefs = cssChunks.map((c) => `http://www.example.com/assets/${c}`);
 
     stylesheetRefs.forEach((r) => expect(cssRefs).contains(r));
+  });
+
+  it("manifest json includes preload information", async () => {
+    expect(fs.existsSync(manifestFile));
+    const manifestJson = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+    expect(manifestJson.preloadModules).toStrictEqual([
+      'http:/www.example.com/assets/index-anaWoCzC.js',
+      'http:/www.example.com/assets/index-B2KHv6gp.js',
+      'http:/www.example.com/assets/index-DR3rjWxH.js',
+      'http:/www.example.com/assets/index-q1TMq3ZU.js'
+    ])
+    expect(manifestJson.preloadStylesheets).toStrictEqual([
+      'http:/www.example.com/assets/index-8_aBiA4K.css',
+      'http:/www.example.com/assets/index-D8XkVD9g.css',
+      'http:/www.example.com/assets/index-DgcS6T3X.css'
+    ])
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,9 @@ export default function VitePluginPreloadAll(
         const existingLinks = getExistingLinks(dom);
 
         for (const bundle of Object.values(ctx.bundle)) {
-          const path = normalize(resolve(base, bundle.fileName));
-
+          const path = resolve(base, bundle.fileName);
           if (
-            existingLinks.includes(path) ||
+            existingLinks.includes(normalize(path)) ||
             !mergedOptions.shouldPreload(bundle)
           ) {
             continue;

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,6 +22,10 @@ export interface PreloadOptions {
    * @default () => true
    */
   shouldPreload: (chunkInfo: OutputChunk | OutputAsset) => boolean;
+  /**
+   * @default undefined
+   */
+  generatePreloadManifestJsonPath?: string
 }
 
 export const defaultOptions: PreloadOptions = {


### PR DESCRIPTION
Fixes #15

Add new option `generatePreloadManifestJsonPath`.

If supplied, it will either mutate the existing manifest (eg when supplying `.vite/manifest.json`), or will create a new file (eg `custom.json`), depending if the file already exists.
